### PR TITLE
fix: add space between multiple filters in AQL

### DIFF
--- a/src/main/scala/com/arangodb/spark/rdd/ArangoRDD.scala
+++ b/src/main/scala/com/arangodb/spark/rdd/ArangoRDD.scala
@@ -56,11 +56,7 @@ class ArangoRDD[T: ClassTag](
   private def createCursor(arangoDB: ArangoDB, readOptions: ReadOptions, partition: ArangoPartition)(implicit clazz: ClassTag[T]): ArangoCursor[T] =
     arangoDB.db(readOptions.database).query(s"FOR doc IN @@col ${createFilter()} RETURN doc", partition.bindVars.asJava, partition.queryOptions, clazz.runtimeClass.asInstanceOf[Class[T]])
 
-  private def createFilter(): String =
-    conditions match {
-      case Nil => ""
-      case _   => conditions.map { "FILTER ".concat(_) } reduce { (x, y) => x + y }
-    }
+  private def createFilter(): String = conditions.map("FILTER " + _).mkString(" ")
 
   /**
    * Adds a filter condition. If used multiple times, the conditions will be combined with a logical AND.

--- a/src/test/scala/com/arangodb/spark/ArangoSparkReadTest.scala
+++ b/src/test/scala/com/arangodb/spark/ArangoSparkReadTest.scala
@@ -82,6 +82,8 @@ class ArangoSparkReadTest extends FunSuite with Matchers with BeforeAndAfterAll 
     val rdd = ArangoSpark.load[TestEntity](sc, COLLECTION, ReadOptions(DB))
     val rdd2 = rdd.filter("doc.test <= 50")
     rdd2.count() should be(50)
+    val rdd3 = rdd.filter("40 < doc.test").filter("doc.test <= 50")
+    rdd3.count() should be(10)
   }
   
   test("load all documents from collection with load balancing") {


### PR DESCRIPTION
This PR applies a bugfix for the following bug: when adding multiple filters, the corresponding strings are concatenated in AQL without extra spacing. Because of that, the statement `rdd.filter("40 < doc.test").filter("doc.test <= 50")` throws an exception:

`arangodb.ArangoDBException: Response: 400, Error: 1501 - AQL: syntax error, unexpected identifier near 'doc.test <= 50 RETURN doc' at position 1:45 (while parsing)`

The reason is (unfortunately not visible from the exception message!) that the generated AQL contains the substring `" FILTER 40 < doc.testFILTER doc.test <= 50 "`.

The solution is to add space between multiple filter statements in [`ArangoRDD.createFilter()`.](https://github.com/arangodb/arangodb-spark-connector/blob/228bfb85535ba4c4771aea9018d7b06442056600/src/main/scala/com/arangodb/spark/rdd/ArangoRDD.scala#L59)
This is achieved via an additional code simplification that uses `mkString()` rather than pattern matching plus a later `reduce()`.

Finally, the existing test "load documents from collection with filter statement" is extended by the above test for multiple filters.